### PR TITLE
Fix for nestjs v6

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Project forked from https://github.com/xiz0r/nestjs-apm.git with a fix for nestj
 
 ## Installation
 ```
-$ npm i nestjs-apm
+$ npm i nestjs-apm-v6
 ```
 ## NestJs config
 ### main.ts (first line)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# nestjs-apm
+# nestjs-apm-v6
+
+Project forked from https://github.com/xiz0r/nestjs-apm.git with a fix for nestjs V6
 
 ## Installation
 ```
@@ -8,7 +10,7 @@ $ npm i nestjs-apm
 ### main.ts (first line)
 
 ```
-import { apm } from 'nestjs-apm';
+import { apm } from 'nestjs-apm-v6';
 ...
 ```
 
@@ -22,7 +24,7 @@ if (apm.isStarted()) {
 
 ```
 ...
-import { ApmModule } from 'nestjs-apm';
+import { ApmModule } from 'nestjs-apm-v6';
 ...
 ```
 

--- a/lib/apm.interceptor.ts
+++ b/lib/apm.interceptor.ts
@@ -1,4 +1,9 @@
-import { Injectable, NestInterceptor, ExecutionContext } from '@nestjs/common';
+import {
+  Injectable,
+  NestInterceptor,
+  ExecutionContext,
+  CallHandler
+} from '@nestjs/common';
 import { Observable } from 'rxjs';
 import { catchError } from 'rxjs/operators';
 import { ApmService } from './apm.service';
@@ -9,9 +14,9 @@ export class ApmInterceptor implements NestInterceptor {
 
   intercept(
     context: ExecutionContext,
-    call$: Observable<any>
-  ): Observable<any> {
-    return call$.pipe(
+    next: CallHandler
+  ): Observable<Response> {
+    return next.handle().pipe(
       catchError(error => {
         this.apmService.captureError(error);
         throw error;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nestjs-apm-v6",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "NestJs v6 Elastic APM Module",
   "directories": {
     "lib": "lib"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nestjs-apm",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "NestJs Elastic APM Module",
   "directories": {
     "lib": "lib"
@@ -36,8 +36,8 @@
     ]
   },
   "devDependencies": {
-    "@nestjs/common": "^5.5.0",
-    "@nestjs/core": "^5.5.0",
+    "@nestjs/common": "^6.5.3",
+    "@nestjs/core": "^6.5.3",
     "@types/node": "^7.0.41",
     "husky": "^1.3.1",
     "lint-staged": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "nestjs-apm",
-  "version": "1.0.8",
-  "description": "NestJs Elastic APM Module",
+  "name": "nestjs-apm-v6",
+  "version": "1.0.0",
+  "description": "NestJs v6 Elastic APM Module",
   "directories": {
     "lib": "lib"
   },
@@ -13,7 +13,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/xiz0r/nestjs-apm.git"
+    "url": "git+https://github.com/enissay-git/nestjs-apm-v6.git"
   },
   "keywords": [
     "NestJS",
@@ -21,11 +21,14 @@
     "APM"
   ],
   "author": "Juan Colo",
+  "contributors": [
+    "Enissay-git <https://github.com/enissay-git> (https://github.com/enissay-git)"
+  ],
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/xiz0r/nestjs-apm/issues"
+    "url": "https://github.com/enissay-git/nestjs-apm-v6/issues"
   },
-  "homepage": "https://github.com/xiz0r/nestjs-apm#readme",
+  "homepage": "https://github.com/enissay-git/nestjs-apm-v6#readme",
   "dependencies": {
     "elastic-apm-node": "^2.1.0"
   },


### PR DESCRIPTION
If you validate this you can update the url of git if you create a new npm module for v6