### PR TITLE
fix/export-method-start

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ import { apm } from 'nestjs-apm';
 ```
 
 ```
+apm.start();
 if (apm.isStarted()) {
 	console.log('APM running');
 }

--- a/lib/start.ts
+++ b/lib/start.ts
@@ -1,2 +1,6 @@
-const apm = require('elastic-apm-node').start();
+const elasticApm = require('elastic-apm-node');
+const apm = {
+  isStarted: (): boolean => elasticApm.isStarted(),
+  start: (options?): any => elasticApm.start(options)
+};
 export { apm };


### PR DESCRIPTION
 - when implementing the library and a project with docker, I had difficulties for my server after listening to my agent because the library was not passing the .env parameters. With this implementation, the start is performed within the project's main, making the library read the parameters from the .env file